### PR TITLE
Return samples for PDDLStream.

### DIFF
--- a/include/asar_hybrid_tmp/grasp_server.h
+++ b/include/asar_hybrid_tmp/grasp_server.h
@@ -920,6 +920,13 @@ double getManipulabilityScore(Eigen::VectorXd jointValues)
 
     samplePosesFromNeedle("insert",M_PI/8, samples_num_, samples);
     sortPosesByHighestManipulabilityScore(samples, sortedSamples);
+
+    for (auto s : sortedSamples)
+        {
+          geometry_msgs::Pose p;
+          poseSE3ToMsg(s.pose, p);
+          res.samples.push_back(p);
+        }
     
 
     return true;


### PR DESCRIPTION
PDDLStream fails because the grasp samples are never returned in the service get_grasp_samples. As a remedy, I assign the samples to the response in the callback function.